### PR TITLE
hotfix of user login and create problem:

### DIFF
--- a/sooljottagrae/sooljottagrae/settings/partials/base.py
+++ b/sooljottagrae/sooljottagrae/settings/partials/base.py
@@ -188,8 +188,8 @@ REST_FRAMEWORK = {
         # 'rest_framework.authentication.BasicAuthentication',
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
 
-        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
-        'rest_framework_social_oauth2.authentication.SocialAuthentication',
+        # 'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        # 'rest_framework_social_oauth2.authentication.SocialAuthentication',
     ),
 }
 
@@ -198,7 +198,7 @@ REST_FRAMEWORK = {
 AUTHENTICATION_BACKENDS = [
         'social.backends.facebook.FacebookOAuth2',
 
-        'rest_framework_social_oauth2.backends.DjangoOAuth2',
+        # 'rest_framework_social_oauth2.backends.DjangoOAuth2',
 
         'django.contrib.auth.backends.ModelBackend',
 ]


### PR DESCRIPTION
When the oauth2 provider and rest_freamework social oauth is added in rest framework, the login and other authentication related pages pops up an error. Probably an error due to the rest framework's social
authentication package for api.
